### PR TITLE
changed bad stock symbol response

### DIFF
--- a/stock_portfolio/views/portfolio.py
+++ b/stock_portfolio/views/portfolio.py
@@ -23,7 +23,7 @@ def get_stock_view(request):
             data = response.json()
             return {'company': data}
         except ValueError:
-            return HTTPNotFound()
+            return {'message': 'There is no stock with that symbol.'}
 
     if request.method == 'POST':
 


### PR DESCRIPTION
- [x] searching for a invalid stock symbol should not 404. Instead it should reload the search page with a message to the user that there is no stock by that name. 